### PR TITLE
Fixed bug - No rule to make target 'stream_infer', needed by 'all'

### DIFF
--- a/apps/stream_infer/Makefile
+++ b/apps/stream_infer/Makefile
@@ -1,6 +1,6 @@
 
 .PHONY: all
-all: stream_infer
+all: run
 
 .PHONY: squeezenet
 googlenet: 


### PR DESCRIPTION
System: Ubuntu 16.04 native
User account: Admin, but not the same admin account in which sdk was installed

**Steps to reproduce**:
```
cd ~/workspace
git clone https://github.com/movidius/ncappzoo
cd ncappzoo
make (or make all)
```
Error log: [stream_infer_make_errorlog.txt](https://github.com/movidius/ncappzoo/files/1398989/stream_infer_make_errorlog.txt)

NOTE: ```make run``` works fine without this fix.