### PR TITLE
Fix stream infer makefile

### DIFF
--- a/apps/stream_infer/Makefile
+++ b/apps/stream_infer/Makefile
@@ -1,15 +1,31 @@
 
 .PHONY: all
-all: run
+all: gendernet googlenet squeezenet alexnet
+
+.PHONY: gendernet
+gendernet: 
+	@echo "\nmaking gendernet"
+	(cd ../../caffe/GenderNet; make compile;)
+
+.PHONY: googlenet
+googlenet: 
+	@echo "\nmaking googlenet"
+	(cd ../../caffe/GoogLeNet; make compile;)
 
 .PHONY: squeezenet
-googlenet: 
+squeezenet:
 	@echo "\nmaking squeezenet"
 	(cd ../../caffe/SqueezeNet; make compile;)
 
+.PHONY: alexnet
+alexnet:
+	@echo "\nmaking alexet"
+	(cd ../../caffe/AlexNet; make compile;)
+
+
 .PHONY: run
-run: googlenet
-	@echo "\nmaking run";
+run: all
+	@echo "\nRunning stream_infer.py";
 	python3 stream_infer.py
 
 .PHONY: help
@@ -22,5 +38,8 @@ help:
 
 clean: clean
 	@echo "\nmaking clean";
+	(cd ../../caffe/GenderNet; make clean;);
+	(cd ../../caffe/GoogLeNet; make clean;);
+	(cd ../../caffe/SqueezeNet; make clean;);
 
 

--- a/apps/stream_infer/Makefile
+++ b/apps/stream_infer/Makefile
@@ -41,5 +41,6 @@ clean: clean
 	(cd ../../caffe/GenderNet; make clean;);
 	(cd ../../caffe/GoogLeNet; make clean;);
 	(cd ../../caffe/SqueezeNet; make clean;);
+	(cd ../../caffe/AlexNet; make clean;);
 
 

--- a/apps/stream_infer/stream_infer.py
+++ b/apps/stream_infer/stream_infer.py
@@ -38,21 +38,20 @@ import numpy
 NETWORK_IMAGE_WIDTH = 227       # the width of images the network requires
 NETWORK_IMAGE_HEIGHT = 227      # the height of images the network requires
 NETWORK_IMAGE_FORMAT = "BGR"    # the format of the images the network requires
-NETWORK_DIRECTORY = "../../caffe/Gender/" # directory of the network this directory needs to
+NETWORK_DIRECTORY = "../../caffe/GenderNet/" # directory of the network this directory needs to
                                 # have 3 files: "graph", "stat.txt" and "categories.txt"
 NETWORK_STAT_TXT = "./gendernet_stat.txt"    # stat.txt for networ
 NETWORK_CATEGORIES_TXT = "./gendernet_categories.txt" # categories.txt for network
 
-
 NETWORK_IMAGE_WIDTH = 224           # the width of images the network requires
 NETWORK_IMAGE_HEIGHT = 224          # the height of images the network requires
-NETWORK_IMAGE_FORMAT = BGR"        # the format of the images the network requires
+NETWORK_IMAGE_FORMAT = "BGR"        # the format of the images the network requires
 NETWORK_DIRECTORY = "../../caffe/GoogLeNet/"  # directory of the network this directory needs to
                                     # have 3 files: "graph", "stat.txt" and "categories.txt"
 NETWORK_STAT_TXT = "./googlenet_stat.txt"    # stat.txt for networ
 NETWORK_CATEGORIES_TXT = "./googlenet_categories.txt" # categories.txt for network
-
 '''
+
 NETWORK_IMAGE_WIDTH = 227                     # the width of images the network requires
 NETWORK_IMAGE_HEIGHT = 227                    # the height of images the network requires
 NETWORK_IMAGE_FORMAT = "BGR"                  # the format of the images the network requires
@@ -68,7 +67,6 @@ NETWORK_DIRECTORY = "../../caffe/AlexNet/"    # directory of the network this di
                                     # have 3 files: "graph", "stat.txt" and "categories.txt
 NETWORK_STAT_TXT = "./alexnet_stat.txt"    # stat.txt for networ
 NETWORK_CATEGORIES_TXT = "./alexnet_categories.txt" # categories.txt for network
-
 '''
 
 # The capture dimensions of the image need to be a multiple of 4 (the image will be cropped back down for inferences)


### PR DESCRIPTION
Updated Makefile to generate all network graphs specified in stream_infer.py. This allows the user to simply uncomment any network block in stream_infer.py and do a make run to run the program using the specified network.

This commit was tested by running the following sequence for each network (GenderNet, GooLeNet, SqueezeNet, AlexNet)

1. make - To ensure it builds all dependencies needed to run stream_infer using any of the available networks
2. make clean - To ensure all intermediate files are properly removed
3. make all - Same as running make
4. make run - To ensure stream_infer runs properly
5. make clean - To remove intermediate files before committing changes