### PR TITLE
Fix caffe makefile

### DIFF
--- a/apps/stream_infer/Makefile
+++ b/apps/stream_infer/Makefile
@@ -1,15 +1,31 @@
 
 .PHONY: all
-all: run
+all: gendernet googlenet squeezenet alexnet
+
+.PHONY: gendernet
+gendernet: 
+	@echo "\nmaking gendernet"
+	(cd ../../caffe/GenderNet; make compile;)
+
+.PHONY: googlenet
+googlenet: 
+	@echo "\nmaking googlenet"
+	(cd ../../caffe/GoogLeNet; make compile;)
 
 .PHONY: squeezenet
-googlenet: 
+squeezenet:
 	@echo "\nmaking squeezenet"
 	(cd ../../caffe/SqueezeNet; make compile;)
 
+.PHONY: alexnet
+alexnet:
+	@echo "\nmaking alexet"
+	(cd ../../caffe/AlexNet; make compile;)
+
+
 .PHONY: run
-run: googlenet
-	@echo "\nmaking run";
+run: all
+	@echo "\nRunning stream_infer.py";
 	python3 stream_infer.py
 
 .PHONY: help
@@ -22,5 +38,8 @@ help:
 
 clean: clean
 	@echo "\nmaking clean";
+	(cd ../../caffe/GenderNet; make clean;);
+	(cd ../../caffe/GoogLeNet; make clean;);
+	(cd ../../caffe/SqueezeNet; make clean;);
 
 

--- a/apps/stream_infer/Makefile
+++ b/apps/stream_infer/Makefile
@@ -41,5 +41,6 @@ clean: clean
 	(cd ../../caffe/GenderNet; make clean;);
 	(cd ../../caffe/GoogLeNet; make clean;);
 	(cd ../../caffe/SqueezeNet; make clean;);
+	(cd ../../caffe/AlexNet; make clean;);
 
 

--- a/apps/stream_infer/stream_infer.py
+++ b/apps/stream_infer/stream_infer.py
@@ -38,21 +38,20 @@ import numpy
 NETWORK_IMAGE_WIDTH = 227       # the width of images the network requires
 NETWORK_IMAGE_HEIGHT = 227      # the height of images the network requires
 NETWORK_IMAGE_FORMAT = "BGR"    # the format of the images the network requires
-NETWORK_DIRECTORY = "../../caffe/Gender/" # directory of the network this directory needs to
+NETWORK_DIRECTORY = "../../caffe/GenderNet/" # directory of the network this directory needs to
                                 # have 3 files: "graph", "stat.txt" and "categories.txt"
 NETWORK_STAT_TXT = "./gendernet_stat.txt"    # stat.txt for networ
 NETWORK_CATEGORIES_TXT = "./gendernet_categories.txt" # categories.txt for network
 
-
 NETWORK_IMAGE_WIDTH = 224           # the width of images the network requires
 NETWORK_IMAGE_HEIGHT = 224          # the height of images the network requires
-NETWORK_IMAGE_FORMAT = BGR"        # the format of the images the network requires
+NETWORK_IMAGE_FORMAT = "BGR"        # the format of the images the network requires
 NETWORK_DIRECTORY = "../../caffe/GoogLeNet/"  # directory of the network this directory needs to
                                     # have 3 files: "graph", "stat.txt" and "categories.txt"
 NETWORK_STAT_TXT = "./googlenet_stat.txt"    # stat.txt for networ
 NETWORK_CATEGORIES_TXT = "./googlenet_categories.txt" # categories.txt for network
-
 '''
+
 NETWORK_IMAGE_WIDTH = 227                     # the width of images the network requires
 NETWORK_IMAGE_HEIGHT = 227                    # the height of images the network requires
 NETWORK_IMAGE_FORMAT = "BGR"                  # the format of the images the network requires
@@ -68,7 +67,6 @@ NETWORK_DIRECTORY = "../../caffe/AlexNet/"    # directory of the network this di
                                     # have 3 files: "graph", "stat.txt" and "categories.txt
 NETWORK_STAT_TXT = "./alexnet_stat.txt"    # stat.txt for networ
 NETWORK_CATEGORIES_TXT = "./alexnet_categories.txt" # categories.txt for network
-
 '''
 
 # The capture dimensions of the image need to be a multiple of 4 (the image will be cropped back down for inferences)

--- a/caffe/AlexNet/Makefile
+++ b/caffe/AlexNet/Makefile
@@ -121,12 +121,15 @@ help:
 	@echo "  make run_py - runs the run.py python example program:";
 	@echo "  make clean - removes all created content"
 
+clean_prereqs:
+	@(cd ../../data/ilsvrc12; make clean)
+
 clean_caffe_model:
 	@echo "\nmaking clean_caffe_model"
 	rm -f ${PROTOTXT_FILENAME}
 	rm -f ${CAFFEMODEL_FILENAME}
 
-clean: clean_caffe_model
+clean: clean_prereqs clean_caffe_model
 	@echo "\nmaking clean"
 	rm -f graph
 	rm -f output.gv

--- a/caffe/GenderNet/Makefile
+++ b/caffe/GenderNet/Makefile
@@ -15,6 +15,7 @@ all: profile compile run
 .PHONY: prereqs
 prereqs:
 	@(cd ../../data/age_gender; make)
+	@chmod a+x run.py
 
 .PHONY: prototxt
 prototxt: prereqs
@@ -39,12 +40,14 @@ check: prototxt
 run:
 	./run.py
 
+clean_prereqs:
+	@(cd ../../data/age_gender; make clean)
 
 cleancaffemodel:
 	@rm -f ${PROTOTXT_FILENAME}
 	@rm -f ${CAFFEMODEL_FILENAME}
 
-clean: cleancaffemodel
+clean: clean_prereqs cleancaffemodel
 	@rm -f graph
 	@rm -f output.gv
 	@rm -f output.gv.svg

--- a/caffe/GoogLeNet/Makefile
+++ b/caffe/GoogLeNet/Makefile
@@ -122,12 +122,15 @@ help:
 	@echo "  make run_py - runs the run.py python example program";
 	@echo "  make clean - removes all created content"
 
+clean_prereqs:
+	@(cd ../../data/ilsvrc12; make clean)
+
 clean_caffe_model:
 	@echo "\nmaking clean_caffe_model"
 	rm -f ${PROTOTXT_FILENAME}
 	rm -f ${CAFFEMODEL_FILENAME}
 
-clean: clean_caffe_model
+clean: clean_prereqs clean_caffe_model
 	@echo "\nmaking clean"
 	rm -f graph
 	rm -f output.gv

--- a/caffe/SqueezeNet/Makefile
+++ b/caffe/SqueezeNet/Makefile
@@ -130,6 +130,9 @@ help:
 	@echo "  make run_py - runs the run.py python example program";
 	@echo "  make clean - removes all created content"
 
+clean_prereqs:
+	@(cd ../../data/ilsvrc12; make clean)
+
 clean_caffe_model:
 	@echo "\nmaking clean_caffe_model"
 	rm -f ${PROTOTXT_FILENAME}


### PR DESCRIPTION
Updated Caffe Makefiles to remove intermediate files generated in data directory.

This commit was tested by running the following sequence:

1. `cd apps/stream_infer`
2. `make`
3. `git status` will list all intermediate files created
4. `make clean`
5. `git status` will confirm that all intermediate files have been deleted