### PR TITLE
Updated GoogLeNet/Makefile to use image-classifier

### DIFF
--- a/caffe/GoogLeNet/Makefile
+++ b/caffe/GoogLeNet/Makefile
@@ -89,7 +89,7 @@ check: prototxt caffemodel
 .PHONY: run
 run: compile
 	@echo "\nmaking run"
-	./run.py
+	(cd ../../apps/image-classifier; python3 image-classifier.py;)
 
 .PHONY: run_py
 run_py: compile


### PR DESCRIPTION
This is a quick fix in an attempt to standardize the output format across all networks. This is needed immediately for the upcoming hands-on workshop @ O'Reilly AI Conference, NY.