### PR TITLE
In the testing of Raspberry Pi 3 , the cv.waitKey(0) will cause proce…

### DIFF
--- a/apps/video_face_matcher_multipleFace/video_face_matcher_multiFace.py
+++ b/apps/video_face_matcher_multipleFace/video_face_matcher_multiFace.py
@@ -242,7 +242,7 @@ def main():
     valid_output = []
     for i in validated_image_list:
         validated_image = cv2.imread("./validated_images/"+i)
-        cv2.waitKey(0)
+        cv2.waitKey(1)
         valid_output.append(run_inference(validated_image, graph))
     if (use_camera):
         run_camera(valid_output, validated_image_list, graph)


### PR DESCRIPTION
In the testing of Raspberry Pi 3 , the cv.waitKey(0) will cause process stop, so that the user cannot use demo code directly.
After change to cv.waitKey(1), the demo call of video_face_matcher_multiFace.py can run well, so that developer can run the demo code well. 

