### PR TITLE
fix missing 'compile' target

### DIFF
--- a/tensorflow/tf_models/Makefile
+++ b/tensorflow/tf_models/Makefile
@@ -38,4 +38,5 @@ help:
 clean:
 	@echo $(YELLOW)"\nMaking clean..."$(NOCOLOR);
 	rm -rf models
+compile: all
 

--- a/tensorflow/tf_src/Makefile
+++ b/tensorflow/tf_src/Makefile
@@ -38,4 +38,5 @@ help:
 clean:
 	@echo $(YELLOW)"\nMaking clean..."$(NOCOLOR);
 	rm -rf tensorflow
+compile: all
 


### PR DESCRIPTION
Add missing 'compile target' so a 'make compile' on top will really download and compile **ALL** models