### PR TITLE
inception: fix minor bug in inception makefile

### DIFF
--- a/tensorflow/inception/Makefile
+++ b/tensorflow/inception/Makefile
@@ -128,5 +128,3 @@ help:
 clean:
 	@echo $(YELLOW)"\nMaking clean..."$(NOCOLOR);
 	rm -rf model
-	rm -rf labels.txt
-	rm -rf inception_v3.pb


### PR DESCRIPTION
This is a minor fix in the Inception makefile to avoid cleaning non-existing files. These files are located inside the `model/` directory which is the first one to be removed.