### PR TITLE
remove duplicate import sys

### DIFF
--- a/apps/street_cam/street_cam.py
+++ b/apps/street_cam/street_cam.py
@@ -8,7 +8,6 @@ import sys
 sys.path.insert(0, "../../ncapi2_shim")
 import mvnc_simple_api as mvnc
 
-import sys
 import numpy as np
 import cv2
 import time

--- a/apps/video_face_matcher/video_face_matcher.py
+++ b/apps/video_face_matcher/video_face_matcher.py
@@ -9,7 +9,6 @@ import mvnc_simple_api as mvnc
 #from mvnc import mvncapi as mvnc
 import numpy
 import cv2
-import sys
 import os
 
 EXAMPLES_BASE_DIR='../../'

--- a/apps/video_face_matcher_multipleFace/video_face_matcher_multiFace.py
+++ b/apps/video_face_matcher_multipleFace/video_face_matcher_multiFace.py
@@ -9,7 +9,6 @@ import mvnc_simple_api as mvnc
 #from mvnc import mvncapi as mvnc
 import numpy
 import cv2
-import sys
 import os
 
 EXAMPLES_BASE_DIR='../../'

--- a/apps/video_objects/video_objects.py
+++ b/apps/video_objects/video_objects.py
@@ -7,13 +7,11 @@ import sys
 sys.path.insert(0, "../../ncapi2_shim")
 import mvnc_simple_api as mvnc
 #from mvnc import mvncapi as mvnc
-import sys
 import numpy
 import cv2
 import time
 import csv
 import os
-import sys
 from sys import argv
 
 # name of the opencv window

--- a/caffe/AlexNet/run.py
+++ b/caffe/AlexNet/run.py
@@ -9,7 +9,6 @@ import cv2
 import time
 import csv
 import os
-import sys
 import re
 from os import system
 

--- a/caffe/GenderNet/run.py
+++ b/caffe/GenderNet/run.py
@@ -12,8 +12,6 @@ import cv2
 import time
 import csv
 import os
-import sys
-
 
 def execute_graph(blob,img):
 	mvnc.SetGlobalOption(mvnc.GlobalOption.LOG_LEVEL, 2)

--- a/caffe/ResNet-18/run.py
+++ b/caffe/ResNet-18/run.py
@@ -15,7 +15,6 @@ import cv2
 import time
 import csv
 import os
-import sys
 
 dim=(224,224)
 EXAMPLES_BASE_DIR='../../'


### PR DESCRIPTION
Many apps that use the mvnc_simple_api to convert from ncsdk to ncsdk2 have multiple references to import sys due to find and replace errors.

This update removes the extra imports.